### PR TITLE
#188067891 Refactor: Set the apscheduler log level to warn

### DIFF
--- a/moesifapi/configuration.py
+++ b/moesifapi/configuration.py
@@ -12,7 +12,7 @@ class Configuration(object):
 
     # Your Application Id for authentication/authorization
     application_id = 'SET_ME'
-    version = 'moesifapi-python/1.4.8'
+    version = 'moesifapi-python/1.4.9'
 
     pool_connections = 10
     pool_maxsize = 10

--- a/moesifapi/workers.py
+++ b/moesifapi/workers.py
@@ -132,6 +132,7 @@ class BatchedWorkerPool:
                     replace_existing=True)
 
                 # Avoid passing logging message to the ancestor loggers
+                logging.getLogger('apscheduler').setLevel(logging.WARNING)
                 logging.getLogger('apscheduler.executors.default').setLevel(logging.WARNING)
                 logging.getLogger('apscheduler.executors.default').propagate = False
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.4.8',
+    version='1.4.9',
 
     description='Moesif API Lib for Python',
     long_description=long_description,


### PR DESCRIPTION
Refactor: Set the apscheduler log level to warn & avoid printing unnecessary logs 
Bump version to 1.4.9