### PR TITLE
#188067891 : Added support to refresh connection pool on ConnectionError.

### DIFF
--- a/moesifapi/configuration.py
+++ b/moesifapi/configuration.py
@@ -12,7 +12,7 @@ class Configuration(object):
 
     # Your Application Id for authentication/authorization
     application_id = 'SET_ME'
-    version = 'moesifapi-python/1.5.0'
+    version = 'moesifapi-python/1.5.1'
 
     pool_connections = 10
     pool_maxsize = 10

--- a/moesifapi/http/requests_client.py
+++ b/moesifapi/http/requests_client.py
@@ -12,6 +12,27 @@ from ..configuration import Configuration
 from .http_client import HttpClient
 from .http_response import HttpResponse
 from .http_method_enum import HttpMethodEnum
+from requests.packages.urllib3.util.retry import Retry
+
+
+# Decorator to refresh connection pool on ConnectionError
+def refresh_session(func):
+    # Wrap function with retry once on ConnectionError
+    def wrapper(self, *args, **kwargs):
+        try:
+            result = func(self, *args, **kwargs)
+        except requests.exceptions.ConnectionError as e:
+            # Recreate connection pool after closing it.
+            self.__close__connection_pool__()  # This closes the session and its connection pool
+            self.__create_connection_pool__()  # create connection pool before retrying
+
+            # retry
+            result = func(self, *args, **kwargs)
+
+        return result
+
+    return wrapper
+
 
 class RequestsClient(HttpClient):
 
@@ -20,13 +41,29 @@ class RequestsClient(HttpClient):
     """
 
     # connection pool here
+    def __create_connection_pool__(self):
+        retry_strategy = Retry(
+            total=3,
+            backoff_factor=1,
+            status_forcelist=[429, 500, 502, 503, 504],
+        )
 
-    def __init__(self):
         self.session = requests.Session()
-        self.adapter = HTTPAdapter(pool_connections=Configuration.pool_connections, pool_maxsize=Configuration.pool_maxsize)
+        self.adapter = HTTPAdapter(
+            max_retries=retry_strategy,
+            pool_connections=Configuration.pool_connections,
+            pool_maxsize=Configuration.pool_maxsize
+        )
         self.session.mount('http://', self.adapter)
         self.session.mount('https://', self.adapter)
 
+    def __close__connection_pool__(self):
+        self.session.close()
+
+    def __init__(self):
+        self.__create_connection_pool__()
+
+    @refresh_session
     def execute_as_string(self, request):
         """Execute a given HttpRequest to get a string response back
        
@@ -40,7 +77,7 @@ class RequestsClient(HttpClient):
         auth = None
 
         if request.username or request.password:
-            auth=(request.username, request.password)
+            auth = (request.username, request.password)
 
         # connection pool to make request
         response = self.session.request(HttpMethodEnum.to_string(request.http_method),
@@ -52,7 +89,8 @@ class RequestsClient(HttpClient):
                                         auth=auth)
 
         return self.convert_response(response, False)
-    
+
+    @refresh_session
     def execute_as_binary(self, request):
         """Execute a given HttpRequest to get a binary response back
        
@@ -66,7 +104,7 @@ class RequestsClient(HttpClient):
         auth = None
 
         if request.username or request.password:
-            auth=(request.username, request.password)
+            auth = (request.username, request.password)
         
         response = requests.request(HttpMethodEnum.to_string(request.http_method), 
                                     request.query_url, 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.5.0',
+    version='1.5.1',
 
     description='Moesif API Lib for Python',
     long_description=long_description,


### PR DESCRIPTION
The change addresses the following scenarios in connection management:
- Initialization: A connection pool is established in SDK when the service starts up.
- Connection Maintenance: For systems that don't support keep-alive functionality, connections may close unexpectedly.
- Error Handling: If the connection becomes inactive, the system throws a `ConnectionError` when attempting to log new events to the Moesif. We refresh connection pool and retry.