### PR TITLE
#187479193 Refactor: Perf improvement of serde - Use json instead of jsonpickle

### DIFF
--- a/moesifapi/configuration.py
+++ b/moesifapi/configuration.py
@@ -12,7 +12,7 @@ class Configuration(object):
 
     # Your Application Id for authentication/authorization
     application_id = 'SET_ME'
-    version = 'moesifapi-python/1.5.3'
+    version = 'moesifapi-python/1.5.4'
 
     pool_connections = 10
     pool_maxsize = 10

--- a/moesifapi/workers.py
+++ b/moesifapi/workers.py
@@ -65,10 +65,7 @@ class Worker:
     def send_events(self, batch_events):
         try:
             logger.debug("Sending events to Moesif")
-            batch_events_api_response = self.api_client.create_events_batch(batch_events)
-            # Update the configuration if necessary
-            etag = batch_events_api_response.get("X-Moesif-Config-ETag")
-            self.config.check_and_update(etag)
+            self.api_client.create_events_batch(batch_events)
             if self.debug:
                 logger.debug("Events sent successfully to Moesif")
         except Exception as ex:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 requests>=2.32.0
 urllib3>=1.26.5
-jsonpickle==3.3.0
 python-dateutil>=2.8.2
-isodatetimehandler==1.0.2
 pytest>=6.0
 apscheduler==3.10.4
 readerwriterlock==1.0.9

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.5.3',
+    version='1.5.4',
 
     description='Moesif API Lib for Python',
     long_description=long_description,
@@ -82,8 +82,8 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['requests', 'jsonpickle',
-                      'python-dateutil', 'isodatetimehandler',
+    install_requires=['requests',
+                      'python-dateutil', 
                       'readerwriterlock>=1.0.9',
                       'apscheduler>=3.10.4'
                       ],


### PR DESCRIPTION
Refactor: Use json instead of jsonpickle to improve performance of serialization / deserialization
Refactor: Skip checks for config eTag from response as scheduled job will fetch config 
Refactor: Remove unused dependencies
Bump version to 1.5.4