### PR TITLE
#CS-4 Refactor: Ensure json parsed when fetching the config

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-﻿Copyright (c) 2019 Moesif, Inc
+﻿Copyright (c) 2025 Moesif, Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/moesifapi/app_config/app_config.py
+++ b/moesifapi/app_config/app_config.py
@@ -26,19 +26,17 @@ class AppConfig:
     def parse_configuration(self, config, debug):
         """Parse configuration object and return Etag, sample rate and last updated time"""
         try:
-            return config.headers.get("X-Moesif-Config-ETag"), json.loads(config.raw_body).get('sample_rate', 100), datetime.utcnow()
+            return config.headers.get("X-Moesif-Config-ETag"), None, datetime.utcnow()
         except:
             if debug:
                 logger.info('Error while parsing the configuration object, setting the sample rate to default')
             return None, 100, datetime.utcnow()
 
-    def get_sampling_percentage(self, event_data, config, user_id, company_id):
+    def get_sampling_percentage(self, event_data, config_body, user_id, company_id):
         """Get sampling percentage"""
 
-        if config is not None:
+        if config_body is not None:
             try:
-                config_body = json.loads(config.raw_body)
-
                 user_sample_rate = config_body.get('user_sample_rate', None)
 
                 company_sample_rate = config_body.get('company_sample_rate', None)

--- a/moesifapi/configuration.py
+++ b/moesifapi/configuration.py
@@ -12,7 +12,7 @@ class Configuration(object):
 
     # Your Application Id for authentication/authorization
     application_id = 'SET_ME'
-    version = 'moesifapi-python/1.5.4'
+    version = 'moesifapi-python/1.5.5'
 
     pool_connections = 10
     pool_maxsize = 10

--- a/moesifapi/governance_manager.py
+++ b/moesifapi/governance_manager.py
@@ -264,11 +264,9 @@ class GovernanceRulesManager:
     }
     return fields
 
-  def govern_request(self, config, event_info, user_id, company_id, request_body, request_headers):
+  def govern_request(self, config_json, event_info, user_id, company_id, request_body, request_headers):
 
     request_fields = self.prepare_request_fields(event_info, request_body)
-
-    config_json = json.loads(config.raw_body)
 
     response_holder = {
       'status': None,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.5.4',
+    version='1.5.5',
 
     description='Moesif API Lib for Python',
     long_description=long_description,


### PR DESCRIPTION
Refactor: Ensure json parsed when fetching the config 
Refactor: Remove locks when reading sampling / gov rules 
Bump version to 1.5.5